### PR TITLE
ispravka mog prethodnog pull request-a

### DIFF
--- a/source/FreeplayState.hx
+++ b/source/FreeplayState.hx
@@ -99,7 +99,7 @@ class FreeplayState extends MusicBeatState {
 		background.screenCenter();
 		add(background);
 
-		velocityBG = new FlxBackdrop(FlxGridOverlay.create(30, 30, 60, 60, true, 0x3B161932, 0x0), XY);
+		velocityBG = new FlxBackdrop(FlxGridOverlay.createGrid(30, 30, 60, 60, true, 0x3B161932, 0x0), XY);
 		velocityBG.velocity.set(FlxG.random.bool(50) ? 90 : -90, FlxG.random.bool(50) ? 90 : -90);
 		velocityBG.visible = ClientPrefs.velocityBackground;
 		add(velocityBG);

--- a/source/FreeplayState.hx
+++ b/source/FreeplayState.hx
@@ -99,7 +99,7 @@ class FreeplayState extends MusicBeatState {
 		background.screenCenter();
 		add(background);
 
-		velocityBG = new FlxBackdrop(Paths.image('velocity_background'), XY);
+		velocityBG = new FlxBackdrop(FlxGridOverlay.create(30, 30, 60, 60, true, 0x3B161932, 0x0), XY);
 		velocityBG.velocity.set(FlxG.random.bool(50) ? 90 : -90, FlxG.random.bool(50) ? 90 : -90);
 		velocityBG.visible = ClientPrefs.velocityBackground;
 		add(velocityBG);


### PR DESCRIPTION
[`FlxGridOverlay.create`](https://api.haxeflixel.com/flixel/addons/display/FlxGridOverlay.html#create) pravi nov FlxSprite, dok [**FlxGridOverlay.createGrid**](https://api.haxeflixel.com/flixel/addons/display/FlxGridOverlay.html#createGrid) pravi BitmapData, [BitmapData](https://api.haxeflixel.com/flash/display/BitmapData.html) je jedan od [FlxGraphicAsset](https://api.haxeflixel.com/flixel/system/FlxGraphicAsset.html)-a.

ovaj put bi trebalo stvarno da radi
kockice će možda biti manje nego pre, nisam siguran da li sam izmerio tačne dimenzije.